### PR TITLE
feat: add dropdown to toggle themes

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
     );
   </script>
 </head>
-<body class="bg-gray-900 dark:bg-gray-700">
+<body class="bg-gray-100 dark:bg-gray-700">
 <div id="root">
   <div class="app-loading">
     <svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { twMerge } from 'tailwind-merge';
 
-type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   startIcon?: React.FunctionComponent<{ className?: string }>;
   endIcon?: React.FunctionComponent<{ className?: string }>;
 };
@@ -21,7 +21,7 @@ export const Button = ({
         'text-sm flex items-center gap-1 px-2 py-1 rounded-sm border enabled:cursor-pointer',
         'text-gray-900 dark:text-gray-300 border-gray-900 dark:border-gray-300',
         'enabled:hover:bg-gray-900/20 enabled:dark:hover:bg-gray-100/20',
-        'enabled:dark:focus:bg-gray-800/10 enabled:dark:focus:bg-gray-200/10',
+        'enabled:focus:bg-gray-800/10 enabled:dark:focus:bg-gray-200/10',
         'disabled:text-gray-500 disabled:border-gray-500',
         className
       )}

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+
+import { twMerge } from 'tailwind-merge';
+import { FaCheck, FaChevronDown, FaChevronUp } from 'react-icons/fa6';
+
+import { Card } from '../Card';
+import { Text } from '../Text';
+
+export type DropdownOption = {
+  value: string;
+  label: string;
+  icon?: React.FunctionComponent<{ className?: string }>;
+};
+
+export type DropdownProps = {
+  className?: string;
+  onSelect?: (nextOption: string) => void;
+  options: DropdownOption[];
+  selectedOption: DropdownOption['value'];
+};
+
+export const Dropdown = ({
+  className,
+  options,
+  onSelect,
+  selectedOption,
+}: DropdownProps) => {
+  const [isOpen, setIsOpen] = React.useState<boolean>(false);
+
+  const selectedOptionObject = React.useMemo(
+    () => options.find((option) => option.value === selectedOption),
+    [options, selectedOption]
+  );
+
+  const handleSelect = React.useCallback(
+    (nextOption: string) => {
+      onSelect?.(nextOption);
+      setIsOpen(false);
+    },
+    [onSelect]
+  );
+
+  return (
+    <div className={twMerge('relative', className)}>
+      <div
+        className="hover:cursor-pointer rounded-full px-4 py-2 border border-gray-800 dark:border-gray-200 hover:bg-gray-800/20 hover:dark:bg-gray-200/20"
+        onClick={() => setIsOpen((prevState) => !prevState)}
+      >
+        <Text className="flex gap-2 items-center text-sm">
+          {selectedOptionObject?.icon ? (
+            <selectedOptionObject.icon className="w-4 h-4" />
+          ) : null}
+          {selectedOptionObject?.label}
+          {isOpen ? (
+            <FaChevronUp className="ml-2 w-3 h-3" />
+          ) : (
+            <FaChevronDown className="ml-2 w-3 h-3" />
+          )}
+        </Text>
+      </div>
+      {isOpen && (
+        <Card
+          as="ul"
+          className="absolute top-12 right-0 z-1 p-0 overflow-hidden"
+        >
+          {options.map((option) => (
+            <li
+              className="pl-6 pr-12 py-3 hover:cursor-pointer hover:bg-gray-200 hover:dark:bg-gray-600 relative"
+              key={option.value}
+              onClick={() => handleSelect(option.value)}
+            >
+              <Text className="flex gap-2 items-center">
+                {option.icon ? <option.icon className="w-4 h-4" /> : null}
+                {option.label}
+                {selectedOption === option.value ? (
+                  <FaCheck className="w-4 h-4 ml-4 absolute right-4" />
+                ) : null}
+              </Text>
+            </li>
+          ))}
+        </Card>
+      )}
+    </div>
+  );
+};

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,7 +1,8 @@
 import { twMerge } from 'tailwind-merge';
-import { Container } from '../Container';
 
+import { Container } from '../Container';
 import { Logo } from '../Logo';
+import { ThemeDropdown } from '../ThemeDropdown';
 
 export type HeaderProps = {
   className?: string;
@@ -17,7 +18,7 @@ export const Header = ({ className }: HeaderProps) => {
     >
       <Container className="container py-4 flex items-center justify-between">
         <Logo size="large" />
-        <div>Theme Chooser</div>
+        <ThemeDropdown />
       </Container>
     </header>
   );

--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -1,0 +1,17 @@
+import { twMerge } from 'tailwind-merge';
+
+import { Button, ButtonProps } from '../Button';
+
+export type IconButtonProps = ButtonProps;
+
+export const IconButton = ({
+  className,
+  children,
+  ...buttonProps
+}: IconButtonProps) => {
+  return (
+    <Button {...buttonProps} className={twMerge('rounded-full p-2', className)}>
+      {children}
+    </Button>
+  );
+};

--- a/src/components/ThemeDropdown/index.tsx
+++ b/src/components/ThemeDropdown/index.tsx
@@ -1,0 +1,43 @@
+import { FaCircleHalfStroke, FaMoon, FaSun } from 'react-icons/fa6';
+
+import { Themes, useTheme } from '../../providers/ThemeProvider';
+import { Dropdown } from '../Dropdown';
+
+export type ThemeDropdownProps = {
+  className?: string;
+};
+
+export const ThemeDropdown = ({ className }: ThemeDropdownProps) => {
+  const { theme, onThemeChange } = useTheme();
+
+  return (
+    <Dropdown
+      className={className}
+      onSelect={(nextOption) =>
+        onThemeChange?.(
+          ['dark', 'light'].includes(nextOption)
+            ? (nextOption as Themes)
+            : undefined
+        )
+      }
+      selectedOption={theme || 'system'}
+      options={[
+        {
+          value: 'system',
+          label: 'System',
+          icon: FaCircleHalfStroke,
+        },
+        {
+          value: 'light',
+          label: 'Light',
+          icon: FaMoon,
+        },
+        {
+          value: 'dark',
+          label: 'Dark',
+          icon: FaSun,
+        },
+      ]}
+    />
+  );
+};

--- a/src/providers/ThemeProvider/index.tsx
+++ b/src/providers/ThemeProvider/index.tsx
@@ -25,17 +25,23 @@ export const ThemeProvider = ({ children }: ThemeProviderProps) => {
   );
 
   const handleThemeChange = (theme?: Themes) => {
-    localStorage.theme = theme;
-
     if (theme === 'dark') {
+      localStorage.setItem('theme', 'dark');
       document.documentElement.classList.remove('light');
       document.documentElement.classList.add('dark');
     } else if (theme === 'light') {
+      localStorage.setItem('theme', 'light');
       document.documentElement.classList.add('light');
       document.documentElement.classList.remove('dark');
     } else {
+      localStorage.removeItem('theme');
       document.documentElement.classList.remove('light');
-      document.documentElement.classList.remove('dark');
+
+      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
     }
 
     setTheme(theme);


### PR DESCRIPTION
# What

- Add Dropdown to select theme

# How to test
- Checkout to `feat/theme-toggling` branch
- Navigate to the project root folder
- Run `npm install` to install the project dependencies
- Run `npm run dev` to start the development server
- Open the server by accessing `http://localhost:5173/` (or with the configured port) in your browser
- After the application loads, the header should contain a Dropdown to select the theme
- By default, it uses the system selected theme
- Selecting Light should show the Light theme
- Selecting Dark should show the Dark theme
- Selecting System should respect the selected theme system
