### PR TITLE
fix: package json, hide theme label in mobile and reorder data updater

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "lint": "eslint . --ext .ts,.tsx --report-unused-disable-directives --max-warnings 0",
+    "lint": "eslint . --ext .ts,.tsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.69.0",

--- a/src/components/DataUpdater/index.tsx
+++ b/src/components/DataUpdater/index.tsx
@@ -20,7 +20,7 @@ export const DataUpdater = ({
   isUpdating,
 }: DataUpdaterProps) => {
   return (
-    <div className="w-full flex gap-2 justify-end items-center">
+    <div className="w-full flex flex-col-reverse md:flex-row gap-2 justify-end items-end md:items-center">
       {lastUpdated && !isUpdating ? (
         <Text className={twMerge('text-xs', className)}>
           Updated at{' '}

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -50,7 +50,9 @@ export const Dropdown = ({
           {selectedOptionObject?.icon ? (
             <selectedOptionObject.icon className="w-4 h-4" />
           ) : null}
-          {selectedOptionObject?.label}
+          <span className="hidden sm:inline-flex">
+            {selectedOptionObject?.label}
+          </span>
           {isOpen ? (
             <FaChevronUp className="ml-2 w-3 h-3" />
           ) : (


### PR DESCRIPTION
# What

- Fix package.json not being a valid JSON
- Hide theme label in extra small devices
- Reorder update at text in mobile

# How to test

- Checkout to `fix/mobile-minor-layout-fixes` branch
- Navigate to the project root folder
- Run `npm install` to install the project dependencies
- Run `npm run dev` to start the development server
- Open the server by accessing `http://localhost:5173/` (or with the configured port) in your browser
- The theme label in Theme Selector should be hidden in screens with less than 640px of width
- The Data Updated Label should be ordered as columns, with the timestamp below the button, in screens with less than 768px