### PR TITLE
fix: theme dropdown importing type from the wrong folder

### DIFF
--- a/src/components/ThemeDropdown/index.tsx
+++ b/src/components/ThemeDropdown/index.tsx
@@ -2,8 +2,7 @@ import { FaCircleHalfStroke, FaMoon, FaSun } from 'react-icons/fa6';
 
 import { useTheme } from '../../hooks/useTheme';
 import { Dropdown } from '../Dropdown';
-
-import type { Themes } from '../../providers/ThemeProvider';
+import type { Themes } from '../../contexts/ThemeContext';
 
 export type ThemeDropdownProps = {
   className?: string;


### PR DESCRIPTION
# What

- Fix ThemeDropdown importing Themes type from the wrong folder